### PR TITLE
switch from pathlib to os

### DIFF
--- a/iggyenrich/iggy_data_package.py
+++ b/iggyenrich/iggy_data_package.py
@@ -1,9 +1,9 @@
 import abc
 import geopandas as gpd
 import logging
+import os
 import pandas as pd
 from enum import Enum
-from pathlib import Path
 from pydantic import BaseModel, validator
 from pyquadkey2 import quadkey
 from typing import Dict, List, Optional, Union
@@ -87,11 +87,11 @@ class LocalIggyDataPackage(IggyDataPackage):
         if values["iggy_prefix"] != "unified":
             data_loc_suffix = f"_{values['iggy_prefix']}"
         iggy_dir = f"iggy-package{geom_spec}-{values['iggy_version_id']}{data_loc_suffix}"
-        return v or str(Path(values["base_loc"]) / iggy_dir)
+        return v or os.path.join(values["base_loc"], iggy_dir)
 
     @validator("crosswalk_loc", always=True)
     def set_geoms_loc(cls, v, values):
-        return v or str(Path(values["data_loc"]) / f"{values['crosswalk_prefix']}_{values['iggy_version_id']}")
+        return v or os.path.join(values["data_loc"], f"{values['crosswalk_prefix']}_{values['iggy_version_id']}")
 
     def load(self, boundaries: List[str] = [], features: List[str] = []) -> None:
         """Load Iggy data from parquet files into memory"""
@@ -110,7 +110,7 @@ class LocalIggyDataPackage(IggyDataPackage):
         # load requested boundaries + features if they're not already
         for boundary, boundary_features in bounds_features_to_load.items():
             if boundary_features != self.bounds_features.get(boundary):
-                bnd_file = Path(self.data_loc) / f"{self.iggy_prefix}_{boundary}_{self.iggy_version_id}"
+                bnd_file = os.path.join(self.data_loc, f"{self.iggy_prefix}_{boundary}_{self.iggy_version_id}")
                 df = pd.read_parquet(bnd_file)
                 df.columns = df.columns.map(lambda x: str(x) + f"_{boundary}")
                 if boundary_features:

--- a/iggyenrich/iggy_enrich.py
+++ b/iggyenrich/iggy_enrich.py
@@ -1,7 +1,7 @@
 import argparse
 import geopandas as gpd
+import os
 import pandas as pd
-from pathlib import Path
 from pydantic import BaseModel
 from typing import List, Tuple, Union
 
@@ -96,9 +96,8 @@ if __name__ == "__main__":
         help="Name of column in input file containing latitude",
     )
     args = parser.parse_args()
-    filepath = Path(args.filename)
 
-    df = pd.read_csv(filepath)
+    df = pd.read_csv(args.filename)
     pkg_config = {
         "base_loc": args.iggy_base_loc,
         "iggy_version_id": args.iggy_version_id,
@@ -109,4 +108,5 @@ if __name__ == "__main__":
     iggy_data.load()
 
     enriched_gdf = iggy_data.enrich_df(df, longitude_col=args.longitude_col, latitude_col=args.latitude_col)
-    enriched_gdf.to_csv(filepath.parent / f"enriched_{filepath.name}")
+    output_file = os.path.join(os.path.dirname(args.filename), f"enriched_{os.path.basename(args.filename)}")
+    enriched_gdf.to_csv(output_file)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = iggyenrich
-version = 0.0.0
+version = 0.0.1
 author = Iggy
 author_email = support@askiggy.com
 description = Enrich data using Iggy (askiggy.com)


### PR DESCRIPTION
Use of `pathlib` was causing errors with reading parquet from s3.

This PR switches to use `os.path` instead.